### PR TITLE
Feature development and fixes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   build_safe:
@@ -18,6 +19,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
+    - name: Run Clippy
+      run: cargo clippy --no-deps --all-targets
     - name: Run tests
       run: cargo test --verbose
 
@@ -27,6 +30,8 @@ jobs:
      - uses: actions/checkout@v3
      - name: Build
        run: cargo build --verbose --features unsafe
+     - name: Run Clippy
+       run: cargo clippy --no-deps --all-targets --features unsafe
      - name: Run tests
        run: cargo test --verbose --features unsafe
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "value_pool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nonmax",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,14 @@
 version = 3
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "value_pool"
 version = "0.1.0"
+dependencies = [
+ "nonmax",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "value_pool"
 version = "0.2.0"
 edition = "2021"
 license = "MIT"
-description = "This crate implements a ValuePool struct that makes the creation of self-referential datastructures easier and safer."
+description = "This crate implements a ValuePool struct that makes the creation of self-referential data structures easier and safer."
 repository = "https://github.com/MrPoisen/value_pool"
 readme = "Readme.md"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "This crate implements a ValuePool struct that makes the creation of self-referential datastructures easier and safer."
+repository = "https://github.com/MrPoisen/value_pool"
+readme = "Readme.md"
+
 # https://docs.rs/about/metadata
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = []
 unsafe = []
 
 [dependencies]
+nonmax = "0.5.5"
 
 [profile.dev]
 opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "value_pool"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "This crate implements a ValuePool struct that makes the creation of self-referential datastructures easier and safer."
@@ -25,10 +25,6 @@ nonmax = "0.5.5"
 [profile.dev]
 opt-level = 1
 debug = true
-
-[profile.bench]
-strip = "none"
-debug=true
 
 [profile.release]
 strip = "symbols"

--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,8 @@ Take a look at the `examples/` folder.
 
 # Example
 ```rust
+use value_pool::{ValuePool, ValueRef};
+
 #[derive(Debug, Clone)]
 struct Node<T> {
     value: T,

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@ This crate implements a ValuePool struct that makes the creation of self-referen
 - [Docs](https://docs.rs/value_pool/0.1.0/value_pool/)
 
 # Features
-- unsafe - uses unsafe code for (potential) speed improvements. This should not create UB or change the behavior off your code.  
+- `unsafe` - uses unsafe code for (potential) speed improvements. This should not create UB or change the behavior off your code.  
 
 
 # Example
@@ -45,7 +45,7 @@ impl<T> LinkedList<T> {
 
         // Note: There is no guarantee that calling `self.store.push` on an empty store will
         // return ValueRef::new(0). We have to make sure self.start points to the right element
-        if self.store.is_empty() {
+        if self.store.element_count() == 1 { // We just pushed the first value
             self.start = reference;
         }
         self.store.get_mut(self.end)?.next = Some(reference); 

--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,73 @@
+This crate implements a ValuePool struct that makes the creation of self-referential datastructures easier and safer. 
 
+- [Docs](https://docs.rs/value_pool/0.1.0/value_pool/)
+
+# Features
+- unsafe - uses unsafe code for (potential) speed improvements. This should not create UB or change the behavior off your code.  
+
+
+# Example
+```rust
+use value_pool::{ValuePool, ValueRef};
+
+#[derive(Debug, Clone)]
+struct Node<T> { // Our self-referential struct
+    value: T,
+    next: Option<ValueRef<Node<T>>>, // Note the `ValueRef<Node<T>>`
+}
+
+impl<T> Node<T> {
+    fn new(value: T, next: Option<ValueRef<Node<T>>>) -> Node<T> {
+        Node { value, next }
+    }
+}
+#[derive(Debug, Clone)]
+struct LinkedList<T> {
+    start: ValueRef<Node<T>>,
+    end: ValueRef<Node<T>>,
+    store: ValuePool<Node<T>>,
+}
+
+impl<T> LinkedList<T> {
+    pub fn new() -> LinkedList<T> {
+        // We can use a ValueRef equal to 0 and then check in all methods if `store.is_empty`
+        LinkedList {
+            start: (ValueRef::new(0)),
+            end: (ValueRef::new(0)),
+            store: (ValuePool::new()),
+        }
+    }
+
+    pub fn push_back(&mut self, value: T) -> Option<()> {
+        // will return Option<()> here for ease of use
+        // think of reference as a weird "pointer"
+        let reference = self.store.push(Node::new(value, None));
+
+        // Note: There is no guarantee that calling `self.store.push` on an empty store will
+        // return ValueRef::new(0). We have to make sure self.start points to the right element
+        if self.store.is_empty() {
+            self.start = reference;
+        }
+        self.store.get_mut(self.end)?.next = Some(reference); 
+        self.end = reference;
+
+        Some(())
+    }
+
+    pub fn pop_front(&mut self) -> Option<T> {
+        // will return Option<T> here in case self.store is empty
+        if self.store.is_empty() {
+            return None;
+        }
+        // We expect that `self.store.take(self.start)` returns Some(...) if our LinkedList is in a valid state.
+        // We could use `unwrap_unchecked` if we can guarantee that our LinkedList is in such a state or if we don't care about our safety.
+        let first_node = self.store.take(self.start)?;
+        // We can't use `.unwrap` or `?` here, because `first_node` could have no `first_node.next` node.
+        // We don't want a panic or early return. We want to return `first_node.value`.
+        // Note: `ValueRef::default() == ValueRef::new(0)`
+        self.start = first_node.next.unwrap_or_default();
+
+        Some(first_node.value)
+    }
+}
+```

--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,14 @@
-This crate implements a ValuePool struct that makes the creation of self-referential datastructures easier and safer. 
+This crate implements a ValuePool struct that makes the creation of self-referential data structures easier and safer. 
 
-- [Docs](https://docs.rs/value_pool/0.1.0/value_pool/)
+Take a look at the `examples/` folder.
+
+- [Docs](https://docs.rs/value_pool/latest/value_pool/)
 
 # Features
 - `unsafe` - uses unsafe code for (potential) speed improvements. This should not create UB or change the behavior off your code.  
 
+# Todo
+- [ ] enable use of [SmallVec](https://github.com/servo/rust-smallvec) behind a feature once v2 is finished.  
 
 # Example
 ```rust

--- a/examples/linked_list.rs
+++ b/examples/linked_list.rs
@@ -22,8 +22,8 @@ impl<T> LinkedList<T> {
     pub fn new() -> LinkedList<T> {
         // We can use a ValueRef equal to 0 and then check in all methods if `store.is_empty`
         LinkedList {
-            start: (ValueRef::new(0)),
-            end: (ValueRef::new(0)),
+            start: (ValueRef::default()),
+            end: (ValueRef::default()),
             store: (ValuePool::new()),
         }
     }
@@ -37,6 +37,7 @@ impl<T> LinkedList<T> {
         // return ValueRef::new(0). We have to make sure self.start points to the right element
         if self.store.element_count() == 1 { // We just pushed the first value
             self.start = reference;
+            self.end = reference;
         }
         self.store.get_mut(self.end)?.next = Some(reference);
         self.end = reference;
@@ -51,6 +52,7 @@ impl<T> LinkedList<T> {
         }
         // We expect that `self.store.take(self.start)` returns Some(...) if our LinkedList is in a valid state.
         // We could use `unwrap_unchecked` if we can guarantee that our LinkedList is in such a state or if we don't care about our safety.
+        // Or we remove our first check if `self.store.is_empty` and just use the `?` (`self.store.take` will return None if it's empty)
         let first_node = self.store.take(self.start)?;
         // We can't use `.unwrap` or `?` here, because `first_node` could have no `first_node.next` node.
         // We don't want a panic or early return. We want to return `first_node.value`.

--- a/examples/linked_list.rs
+++ b/examples/linked_list.rs
@@ -35,7 +35,8 @@ impl<T> LinkedList<T> {
 
         // Note: There is no guarantee that calling `self.store.push` on an empty store will
         // return ValueRef::new(0). We have to make sure self.start points to the right element
-        if self.store.element_count() == 1 { // We just pushed the first value
+        if self.store.element_count() == 1 {
+            // We just pushed the first value
             self.start = reference;
             self.end = reference;
         }

--- a/examples/linked_list.rs
+++ b/examples/linked_list.rs
@@ -35,7 +35,7 @@ impl<T> LinkedList<T> {
 
         // Note: There is no guarantee that calling `self.store.push` on an empty store will
         // return ValueRef::new(0). We have to make sure self.start points to the right element
-        if self.store.is_empty() {
+        if self.store.element_count() == 1 { // We just pushed the first value
             self.start = reference;
         }
         self.store.get_mut(self.end)?.next = Some(reference);

--- a/examples/linked_list_smart.rs
+++ b/examples/linked_list_smart.rs
@@ -1,4 +1,4 @@
-use value_pool::{ValuePool, ValueRef, smart_value_pool::SmartValuePool};
+use value_pool::{smart_value_pool::SmartValuePool, ValuePool, ValueRef};
 
 #[derive(Debug, Clone)]
 struct Node<T> {
@@ -20,11 +20,13 @@ struct LinkedList<T> {
 }
 
 // Not needed
-fn on_empty<T>(_pool: &mut ValuePool<Node<T>>, _ll: &mut LinkedList<T>) {
-
-}
+fn on_empty<T>(_pool: &mut ValuePool<Node<T>>, _ll: &mut LinkedList<T>) {}
 // ensures that on we always have a valid state when we start from an empty LinkedList
-fn on_empty_push<T>(_pool: &mut ValuePool<Node<T>>, reference: ValueRef<Node<T>>, ll: &mut LinkedList<T>) {
+fn on_empty_push<T>(
+    _pool: &mut ValuePool<Node<T>>,
+    reference: ValueRef<Node<T>>,
+    ll: &mut LinkedList<T>,
+) {
     ll.start = reference;
     ll.end = reference;
 }
@@ -35,7 +37,7 @@ impl<T> LinkedList<T> {
         LinkedList {
             start: (ValueRef::default()),
             end: (ValueRef::default()),
-            store: (SmartValuePool::make_smart(ValuePool::new(), on_empty , on_empty_push)),
+            store: (SmartValuePool::make_smart(ValuePool::new(), on_empty, on_empty_push)),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@
 //! - *unsafe* - Library will use unsafe code to (potentially) improve speed. This could result in UB even though it shouldn't and the behavior of your code should be unchanged.
 use std::{borrow::Borrow, hash::Hash, marker::PhantomData, ops::Deref};
 
+pub mod smart_value_pool;
+
 /// Struct that stores a location of an item in ValuePool. It implements Copy.
 ///
 /// Usually, you get this struct with `from` or `into`:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-
 //! This libraries allows easy use of self-referential structs by storing them in one place, the `ValuePool<T>`
 //! and referencing the stored values with `UntypedValueRef` or `ValueRef<T>`.
 //!
@@ -11,17 +10,17 @@
 //! // You can convert ValueRef<T> to UntypedValueRef and the other way round.
 //! // UntypedValueRef is useful if the type information of ValueRef<T> gets in your way
 //! let untyped_ref_to_first: UntypedValueRef = ref_to_first.into();
-//! 
+//!
 //! // original type information gets lost
 //! let wrongly_typed_ref_to_first: ValueRef<u8> = untyped_ref_to_first.into();  
 //! // Notice the wrong type of `wrongly_typed_ref_to_first`
-//! // Following line would result in compile time error: 
+//! // Following line would result in compile time error:
 //! //  `Trait From<ValueRef<u8>> is not implemented for ValueRef<u32>`
 //! //pool.get(wrongly_typed_ref_to_first); // Error here
 //!
 //! assert_eq!(pool.get(ref_to_first), Some(&12));
 //! assert_eq!(pool.element_count(), 1);
-//! 
+//!
 //! // You can take a value
 //! assert_eq!(pool.take(ref_to_first), Some(12));
 //! assert_eq!(pool.element_count(), 0);
@@ -330,7 +329,7 @@ impl<T> ValuePool<T> {
     }
 
     /// # Safety
-    /// Makes all ValueRefs greater equal than reference point to wrong elements.
+    /// Makes the greatest ValueRef point to the wrong (actually now `None`) element.
     /// This function will not panic or create UB.
     ///
     /// # Complexity

--- a/src/smart_value_pool.rs
+++ b/src/smart_value_pool.rs
@@ -1,12 +1,44 @@
+//! This module implements [`SmartValuePool<T>`] which can automatically call a function if a method call changes it state from empty to one element or vice versa.
 use std::{
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 
-// IDEA: same as value_pool, but it simplifies self-referential structs (especially when the first value is pushed)
 use crate::{ValuePool, ValueRef};
 
-// TODO: more/better documentation
+/// [`SmartValuePool<T, O>`] can automatically call a function if a method call changes it state from empty to one element or vice versa.
+/// ```
+/// use value_pool::{ValuePool, smart_value_pool::SmartValuePool, ValueRef};
+/// 
+/// fn on_empty<T>(pool: &mut ValuePool<T>, text: &mut String) {
+///     println!("Waiting positions in now empty pool: {}", pool.waiting_positions());
+///     text.push_str("|Called on_empty|");
+/// }
+/// 
+/// fn on_empty_push<T>(pool: &mut ValuePool<T>, reference: ValueRef<T>, text: &mut String){
+///     println!("Waiting positions in now 1 element pool: {}", pool.waiting_positions());
+///     text.push_str("|Called on_empty_push|");
+/// }
+/// 
+/// let mut pool: SmartValuePool<usize, String> = SmartValuePool::make_smart(ValuePool::new(), on_empty, on_empty_push);
+/// let mut text = "Start: ".to_string();
+/// let three_ref = pool.smart_push(3usize, &mut text); // prints "Waiting positions in now 1 element pool: 0"
+/// assert_eq!(&text, "Start: |Called on_empty_push|");
+/// assert_eq!(pool.waiting_positions(), 0);
+/// let four_ref = pool.smart_push(4usize, &mut text);
+/// let five_ref = pool.push(5); // No check will happen
+/// let six_ref = pool.push(6); // No check will happen
+/// 
+/// pool.remove(three_ref); // No check
+/// pool.smart_remove(four_ref, &mut text);
+/// pool.smart_remove(five_ref, &mut text);
+/// pool.smart_remove(six_ref, &mut text); // prints "Waiting positions in now empty pool: 3"
+/// // Why 3 waiting positions?: `six_ref` is stored last, so instead of marking its position as empty,
+/// // we remove its position.
+/// // Note: This does **not** reduce the used memory of this `SmartValuePool<T>`
+/// assert_eq!(&text, "Start: |Called on_empty_push||Called on_empty|");
+/// assert_eq!(pool.waiting_positions(), 3);
+/// ```
 #[derive(Debug)]
 pub struct SmartValuePool<T, O> {
     pool: ValuePool<T>,

--- a/src/smart_value_pool.rs
+++ b/src/smart_value_pool.rs
@@ -1,44 +1,59 @@
-use std::{marker::PhantomData, ops::{Deref, DerefMut}};
+use std::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
 // IDEA: same as value_pool, but it simplifies self-referential structs (especially when the first value is pushed)
 use crate::{ValuePool, ValueRef};
 
+// TODO: more/better documentation
 #[derive(Debug)]
 pub struct SmartValuePool<T, O> {
     pool: ValuePool<T>,
     on_empty: fn(&mut ValuePool<T>, &mut O),
-    on_empty_push:  fn(&mut ValuePool<T>, ValueRef<T>, &mut O),
-    object_type: PhantomData<O>
+    on_empty_push: fn(&mut ValuePool<T>, ValueRef<T>, &mut O),
+    object_type: PhantomData<O>,
 }
 
-impl<T,O> Deref for SmartValuePool<T,O> {
+impl<T, O> Deref for SmartValuePool<T, O> {
     type Target = ValuePool<T>;
     fn deref(&self) -> &Self::Target {
         &self.pool
     }
 }
 
-impl<T,O> DerefMut for SmartValuePool<T,O> {
+impl<T, O> DerefMut for SmartValuePool<T, O> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.pool
     }
 }
 
 impl<T, O> SmartValuePool<T, O> {
+    /// Creates a `SmartValuePool` with the given functions.
     #[inline]
-    pub fn make_smart(pool: ValuePool<T>, on_empty: fn(&mut ValuePool<T>, &mut O), on_first_push: fn(&mut ValuePool<T>, ValueRef<T>, &mut O)) -> SmartValuePool<T, O>{
-        SmartValuePool { pool, on_empty, on_empty_push: on_first_push, object_type: (PhantomData)}
+    pub fn make_smart(
+        pool: ValuePool<T>,
+        on_empty: fn(&mut ValuePool<T>, &mut O),
+        on_empty_push: fn(&mut ValuePool<T>, ValueRef<T>, &mut O),
+    ) -> SmartValuePool<T, O> {
+        SmartValuePool {
+            pool,
+            on_empty,
+            on_empty_push,
+            object_type: (PhantomData),
+        }
     }
-
+    /// Same as [`ValuePool<T>::push`] but it will call the previously given `on_empty_push` if needed
     #[inline]
-    pub fn smart_push(&mut self, value: T, object: &mut O) -> ValueRef<T>{
+    pub fn smart_push(&mut self, value: T, object: &mut O) -> ValueRef<T> {
         let tmp = self.pool.push(value);
         if self.pool.element_count() == 1 {
-            (self.on_empty_push) (&mut self.pool, tmp, object);
+            (self.on_empty_push)(&mut self.pool, tmp, object);
         }
         tmp
     }
-
+    
+    /// Same as [`ValuePool<T>::take`] but it will call the previously given `on_empty` if needed
     #[inline]
     pub fn smart_take(&mut self, reference: ValueRef<T>, object: &mut O) -> Option<T> {
         let tmp = self.pool.take(reference);
@@ -48,12 +63,35 @@ impl<T, O> SmartValuePool<T, O> {
         tmp
     }
 
+    /// Same as [`ValuePool<T>::take_unchecked`] but it will call the previously given `on_empty` if needed
+    /// 
+    /// # Safety
+    /// Calling this method with an reference that is out of bounds, is UB. You can check beforehand with [`ValuePool::is_ref_in_bounce`].
     #[inline]
-    pub unsafe fn smart_take_unchecked(&mut self, reference: impl Into<ValueRef<T>>, object: &mut O) -> Option<T> {
+    pub unsafe fn smart_take_unchecked(
+        &mut self,
+        reference: impl Into<ValueRef<T>>,
+        object: &mut O,
+    ) -> Option<T> {
         let tmp = self.take_unchecked(reference);
         if self.is_empty() {
             (self.on_empty)(&mut self.pool, object);
         }
         tmp
     }
+
+    /// Same as [`ValuePool<T>::remove`] but it will call the previously given `on_empty` if needed
+    #[inline]
+    pub fn smart_remove(
+        &mut self,
+        reference: impl Into<ValueRef<T>>,
+        object: &mut O,
+    )  {
+        self.remove(reference);
+        if self.is_empty() {
+            (self.on_empty)(&mut self.pool, object);
+        }
+        
+    }
+
 }

--- a/src/smart_value_pool.rs
+++ b/src/smart_value_pool.rs
@@ -1,0 +1,59 @@
+use std::{marker::PhantomData, ops::{Deref, DerefMut}};
+
+// IDEA: same as value_pool, but it simplifies self-referential structs (especially when the first value is pushed)
+use crate::{ValuePool, ValueRef};
+
+#[derive(Debug)]
+pub struct SmartValuePool<T, O> {
+    pool: ValuePool<T>,
+    on_empty: fn(&mut ValuePool<T>, &mut O),
+    on_empty_push:  fn(&mut ValuePool<T>, ValueRef<T>, &mut O),
+    object_type: PhantomData<O>
+}
+
+impl<T,O> Deref for SmartValuePool<T,O> {
+    type Target = ValuePool<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.pool
+    }
+}
+
+impl<T,O> DerefMut for SmartValuePool<T,O> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.pool
+    }
+}
+
+impl<T, O> SmartValuePool<T, O> {
+    #[inline]
+    pub fn make_smart(pool: ValuePool<T>, on_empty: fn(&mut ValuePool<T>, &mut O), on_first_push: fn(&mut ValuePool<T>, ValueRef<T>, &mut O)) -> SmartValuePool<T, O>{
+        SmartValuePool { pool, on_empty, on_empty_push: on_first_push, object_type: (PhantomData)}
+    }
+
+    #[inline]
+    pub fn smart_push(&mut self, value: T, object: &mut O) -> ValueRef<T>{
+        let tmp = self.pool.push(value);
+        if self.pool.element_count() == 1 {
+            (self.on_empty_push) (&mut self.pool, tmp, object);
+        }
+        tmp
+    }
+
+    #[inline]
+    pub fn smart_take(&mut self, reference: ValueRef<T>, object: &mut O) -> Option<T> {
+        let tmp = self.pool.take(reference);
+        if self.is_empty() {
+            (self.on_empty)(&mut self.pool, object);
+        }
+        tmp
+    }
+
+    #[inline]
+    pub unsafe fn smart_take_unchecked(&mut self, reference: impl Into<ValueRef<T>>, object: &mut O) -> Option<T> {
+        let tmp = self.take_unchecked(reference);
+        if self.is_empty() {
+            (self.on_empty)(&mut self.pool, object);
+        }
+        tmp
+    }
+}


### PR DESCRIPTION
# Added
- `SmartValuePool<T>`
- Example using it
- `cargo clippy` to CI
- `Readme.md` and repository link (to `Cargo.toml`)
- `PartialOrd` and `PartialEq` between `ValueRef<T>` and `UntypedValueRef`

# Changed
- `ValueRef<T>` and `UntypedValueRef` now use `nonmax::NonMaxUsize`
  This results in memory layout optimization. For example: 
  `std::mem::size_of::<UntypedValueRef>() == std::mem::size_of::<Option<UntypedValueRef>>()`

# Removed
- `Deref<usize>`  implementation